### PR TITLE
Initialize window.getRandomValues()

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,24 @@
 
 import { randomBytes } from 'react-native-randombytes'
 exports.randomBytes = exports.rng = exports.pseudoRandomBytes = exports.prng = randomBytes
+
+// implement window.getRandomValues(), for packages that rely on it
+if (typeof window === 'object') {
+  if (!window.crypto) window.crypto = {}
+  if (!window.crypto.getRandomValues) {
+    window.crypto.getRandomValues = function (arr) {
+      if (arr.byteLength != arr.length) {
+        // Get access to the underlying raw bytes
+        arr = new Uint8Array(arr.buffer)
+      }
+      const bytes = randomBytes(arr.length)
+      for (var i = 0; i < bytes.length; i++) {
+        arr[i] = bytes[i]
+      }
+    }
+  }
+}
+
 exports.createHash = exports.Hash = require('create-hash')
 exports.createHmac = exports.Hmac = require('create-hmac')
 
@@ -76,20 +94,3 @@ var publicEncrypt = require('public-encrypt')
     ].join('\n'))
   }
 })
-
-// implement window.getRandomValues(), for packages that rely on it
-if (typeof window === 'object') {
-  if (!window.crypto) window.crypto = {}
-  if (!window.crypto.getRandomValues) {
-    window.crypto.getRandomValues = function (arr) {
-      if (arr.byteLength != arr.length) {
-        // Get access to the underlying raw bytes
-        arr = new Uint8Array(arr.buffer)
-      }
-      const bytes = randomBytes(arr.length)
-      for (var i = 0; i < bytes.length; i++) {
-        arr[i] = bytes[i]
-      }
-    }
-  }
-}

--- a/index.js
+++ b/index.js
@@ -76,3 +76,20 @@ var publicEncrypt = require('public-encrypt')
     ].join('\n'))
   }
 })
+
+// implement window.getRandomValues(), for packages that rely on it
+if (typeof window === 'object') {
+  if (!window.crypto) window.crypto = {}
+  if (!window.crypto.getRandomValues) {
+    window.crypto.getRandomValues = function (arr) {
+      if (arr.byteLength != arr.length) {
+        // Get access to the underlying raw bytes
+        arr = new Uint8Array(arr.buffer)
+      }
+      const bytes = randomBytes(arr.length)
+      for (var i = 0; i < bytes.length; i++) {
+        arr[i] = bytes[i]
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "browserify-cipher": "^1.0.0",
-    "browserify-sign": "^4.0.0",
+    "browserify-sign": "^4.0.4",
     "create-ecdh": "^4.0.0",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
   "name": "react-native-crypto",
   "description": "implementation of crypto for React Native",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "homepage": "https://github.com/mvayngrib/react-native-crypto",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
   "name": "react-native-crypto",
   "description": "implementation of crypto for React Native",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "homepage": "https://github.com/mvayngrib/react-native-crypto",
   "repository": {
     "type": "git",


### PR DESCRIPTION
If window is defined, ensure window.getRandomValues() is also defined (use react-native-randombytes to generate the underlying random data). Also fixes a bug from the original getRandomValues() shim function, which would leave some bytes uninitialized if the passed Typed Array was not Uint8.