### PR TITLE
Fix error with node modules that use randombytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,23 +3,26 @@
 import { randomBytes } from 'react-native-randombytes'
 exports.randomBytes = exports.rng = exports.pseudoRandomBytes = exports.prng = randomBytes
 
-// implement window.getRandomValues(), for packages that rely on it
+// implement crypto.getRandomValues(), for packages that rely on it
+exports.getRandomValues = function getRandomValues (arr) {
+  let orig = arr
+  if (arr.byteLength != arr.length) {
+    // Get access to the underlying raw bytes
+    arr = new Uint8Array(arr.buffer)
+  }
+  const bytes = randomBytes(arr.length)
+  for (var i = 0; i < bytes.length; i++) {
+    arr[i] = bytes[i]
+  }
+
+  return orig
+}
+
+// Also implement window.crypto.getRandomValues(), if missing
 if (typeof window === 'object') {
   if (!window.crypto) window.crypto = {}
   if (!window.crypto.getRandomValues) {
-    window.crypto.getRandomValues = function getRandomValues (arr) {
-      let orig = arr
-      if (arr.byteLength != arr.length) {
-        // Get access to the underlying raw bytes
-        arr = new Uint8Array(arr.buffer)
-      }
-      const bytes = randomBytes(arr.length)
-      for (var i = 0; i < bytes.length; i++) {
-        arr[i] = bytes[i]
-      }
-
-      return orig
-    }
+    window.crypto.getRandomValues = exports.getRandomValues
   }
 }
 


### PR DESCRIPTION
Ran into an issue, with a node module that depends on "randombytes". It appears in the implementation of that module, it checks for the existence of crypto.getRandomValues() (instead of checking for window.crypto.getRandomValues() as some other browserify modules do). In my project's shim.js, I just copied over the implementation from window, and everything seemed to work fine. Should we also be populating crypto.getRandomValues() in react-native-crypto? Here's a PR that does so, thoughts?