### PR TITLE
Add simple getCurves function

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,3 +102,5 @@ exports.randomFillSync = rf.randomFillSync
     ].join('\n'))
   }
 })
+
+exports.getCurves = () => [];


### PR DESCRIPTION
Hi, 

I noticed `crypto.getCurves` is missing from this package.

Now Im not sure if actually no curves are supported, so maybe this could be extended. But I figured returning an empty array is more like what a consumer of the function might expect. 
Right not you naturally get a `... is not a function` Error.

If this gets merged it would be a soltion for this like [this openPgp discussion](https://github.com/openpgpjs/openpgpjs/discussions/1211#discussioncomment-3623550)

